### PR TITLE
fix: create target folder and update config output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,9 @@ docs/_build/
 
 # PyBuilder
 .pybuilder/
-src/target/**
+src/target/*
+!src/target/.gitkeep
+
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/src/config/conf.py
+++ b/src/config/conf.py
@@ -1,5 +1,5 @@
 tasks_config = {
-    "files": {"format": "csv", "output_folder": "src\\output"},
+    "files": {"format": "csv", "output_folder": "src\\target"},
     "ProcessFootballData": {
         "ingress_file_path": "src\\target\\EPL",
         "egress_file_path": "src\\target\\EPL_processed",


### PR DESCRIPTION
## Description
This PR adds the Python scripts for web scraping Premier League football data from the football-data.co.uk website into a structured CSV format. The script extracts information about the games, including the referee, result, venue, bookings and betting odds. Unit tests have not yet been deployed for this process.

## Changes:
Added src/utils/web_crawler.py which includes:

## How to Test:
Install the required dependencies:
```bash
pip install poetry
poetry install
```

## Checklist

- [ ]
 
## Related Issues:
N/A

## Screenshots (if applicable):
N/A

Notes:
Please ensure that you have the necessary permissions to access the website being scraped. If there are any issues with the website structure or data format changes, the script may need to be updated accordingly.